### PR TITLE
fix `include_stacks?` method

### DIFF
--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -30,7 +30,7 @@ module TestProf
 
       # Whether we want to generate flamegraphs
       def include_stacks?
-        @mode == :flamegraph
+        @mode == :flamegraph || @mode == :json
       end
 
       # Whether we want to generate json


### PR DESCRIPTION
Fix bug where `include_stacks?` only worked for `mode == flamegraph`