### PR TITLE
Print complete stats, not merely the raw stats.

### DIFF
--- a/lib/test_prof/factory_prof/printers/json.rb
+++ b/lib/test_prof/factory_prof/printers/json.rb
@@ -14,7 +14,7 @@ module TestProf::FactoryProf
           return log(:info, "No factories detected") if result.raw_stats == {}
 
           path = TestProf::Utils::JSONBuilder.generate(
-            data: result.raw_stats,
+            data: result,
             output: OUTPUT_NAME
           )
 


### PR DESCRIPTION
instead of only printing the `raw_stats` which contains the aggregated statistics. We also are interested in including the `stacks` so we can eventually create a flamegraph to see cascaded factory usage.